### PR TITLE
Fix event return codes and related tests

### DIFF
--- a/state-machine.js
+++ b/state-machine.js
@@ -106,11 +106,11 @@
           return this.error(name, from, to, args, StateMachine.Error.INVALID_TRANSITION, "event " + name + " inappropriate in current state " + this.current);
 
         if (false === StateMachine.beforeEvent(this, name, from, to, args))
-          return StateMachine.CANCELLED;
+          return StateMachine.Result.CANCELLED;
 
         if (from === to) {
           StateMachine.afterEvent(this, name, from, to, args);
-          return StateMachine.NOTRANSITION;
+          return StateMachine.Result.NOTRANSITION;
         }
 
         // prepare a transition method for use EITHER lower down, or by caller if they want an async transition (indicated by an ASYNC return value from leaveState)
@@ -121,6 +121,7 @@
           StateMachine.enterState( fsm, name, from, to, args);
           StateMachine.changeState(fsm, name, from, to, args);
           StateMachine.afterEvent( fsm, name, from, to, args);
+          return StateMachine.Result.SUCCEEDED;
         };
         this.transition.cancel = function() { // provide a way for caller to cancel async transition if desired (issue #22)
           fsm.transition = null;
@@ -130,15 +131,14 @@
         var leave = StateMachine.leaveState(this, name, from, to, args);
         if (false === leave) {
           this.transition = null;
-          return StateMachine.CANCELLED;
+          return StateMachine.Result.CANCELLED;
         }
-        else if ("async" === leave) {
-          return StateMachine.ASYNC;
+        else if (StateMachine.ASYNC === leave) {
+          return StateMachine.Result.ASYNC;
         }
         else {
           if (this.transition)
-            this.transition(); // in case user manually called transition() but forgot to return ASYNC
-          return StateMachine.SUCCEEDED;
+            return this.transition(); // in case user manually called transition() but forgot to return ASYNC
         }
 
       };

--- a/test/test_basics.js
+++ b/test/test_basics.js
@@ -448,16 +448,16 @@ test("event return values (github issue #12) ", function() {
 
   equals(fsm.current, 'stopped', "initial state should be stopped");
 
-  equals(fsm.prepare(), StateMachine.SUCCEEDED, "expected event to have SUCCEEDED");
+  equals(fsm.prepare(), StateMachine.Result.SUCCEEDED, "expected event to have SUCCEEDED");
   equals(fsm.current,   'ready',                "prepare event should transition from stopped to ready");
 
-  equals(fsm.fake(),    StateMachine.CANCELLED, "expected event to have been CANCELLED");
+  equals(fsm.fake(),    StateMachine.Result.CANCELLED, "expected event to have been CANCELLED");
   equals(fsm.current,   'ready',                "cancelled event should not cause a transition");
 
-  equals(fsm.start(),   StateMachine.ASYNC,     "expected event to cause an ASYNC transition");
+  equals(fsm.start(),   StateMachine.Result.ASYNC,     "expected event to cause an ASYNC transition");
   equals(fsm.current,   'ready',                "async transition hasn't happened yet");
 
-  equals(fsm.transition(), StateMachine.SUCCEEDED, "expected async transition to have SUCCEEDED");
+  equals(fsm.transition(), StateMachine.Result.SUCCEEDED, "expected async transition to have SUCCEEDED");
   equals(fsm.current,      'running',              "async transition should now be complete");
 
 });


### PR DESCRIPTION
Return codes are always undefined otherwise.
