### PR TITLE
Add instructions to install from npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Download
 You can download [state-machine.js](https://github.com/jakesgordon/javascript-state-machine/raw/master/state-machine.js),
 or the [minified version](https://github.com/jakesgordon/javascript-state-machine/raw/master/state-machine.min.js)
 
+Using npm:
+
+    npm install --save javascript-state-machine
+
 Alternatively:
 
     git clone git@github.com:jakesgordon/javascript-state-machine


### PR DESCRIPTION
I was trying to install this quickly and wondered if I could get it from npm and found it here:
https://www.npmjs.com/package/javascript-state-machine

Adding it to the readme would help new people find it easily (especially since there're a lot of state machine libraries out there).
