### PR TITLE
Added method that calls transition by given name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ In its simplest form, create a standalone state machine using:
 along with the following members:
 
  * fsm.current       - contains the current state
+ * fsm.event(e)      - call transition named `e`
  * fsm.is(s)         - return true if state `s` is the current state
  * fsm.can(e)        - return true if event `e` can be fired in the current state
  * fsm.cannot(e)     - return true if event `e` cannot be fired in the current state


### PR DESCRIPTION
Lets assume that I have transition named 'warn'
`var TO_WARN = 'warn;'`
So I can call it this way
`fsm.event(TO_WARN);`
