### PR TITLE
Call to transitions() now also returns wildcard transitions

### DIFF
--- a/state-machine.js
+++ b/state-machine.js
@@ -78,7 +78,7 @@
       fsm.is          = function(state) { return (state instanceof Array) ? (state.indexOf(this.current) >= 0) : (this.current === state); };
       fsm.can         = function(event) { return !this.transition && (map[event].hasOwnProperty(this.current) || map[event].hasOwnProperty(StateMachine.WILDCARD)); }
       fsm.cannot      = function(event) { return !this.can(event); };
-      fsm.transitions = function()      { return transitions[this.current]; };
+      fsm.transitions = function()      { return (transitions[this.current] || []).concat(transitions[StateMachine.WILDCARD]); };
       fsm.isFinished  = function()      { return this.is(terminal); };
       fsm.error       = cfg.error || function(name, from, to, args, error, msg, e) { throw e || msg; }; // default behavior when something unexpected happens is to throw an exception, but caller can override this behavior if desired (see github issue #3 and #17)
 


### PR DESCRIPTION
As described in #93, a call to `transitions()` did not return wildcard transitions. This PR fixes that.