### PR TITLE
Typo vaporise/vaporize

### DIFF
--- a/docs/states-and-transitions.md
+++ b/docs/states-and-transitions.md
@@ -29,7 +29,7 @@ A state machine consists of a set of **states**, e.g:
   fsm.state;             // 'solid'
   fsm.melt();
   fsm.state;             // 'liquid'
-  fsm.vaporise();
+  fsm.vaporize();
   fsm.state;             // 'gas'
 ```
 


### PR DESCRIPTION
The demo errors because the state name is misspelled.