### PR TITLE
fix(FEC-9058): shift doesnt consistently work on LG TV browser

### DIFF
--- a/dist/state-machine.js
+++ b/dist/state-machine.js
@@ -503,8 +503,8 @@ mixin(JSM.prototype, {
       plugin.hook(this, 'lifecycle', args);
 
     if (observers.length === 0) {
-      events.shift();
-      return this.observeEvents(events, args, event, previousResult);
+      var nextEvents = events.slice(1);
+      return this.observeEvents(nextEvents, args, event, previousResult);
     }
     else {
       var observer = observers.shift(),


### PR DESCRIPTION

shift doesnt consistently work on LG TV -  doesnt work in LG TV browser with ima midrolls, shift return address instead array as excepted from shift function